### PR TITLE
Encode json with no spaces

### DIFF
--- a/json/src/main/scala/JsonContent.scala
+++ b/json/src/main/scala/JsonContent.scala
@@ -19,7 +19,7 @@ object JsonContent {
     * @return a [[lol.http.ContentEncoder ContentEncoder]] for `io.circe.JSON`.
     */
   def encoder(codec: Codec = Codec.UTF8): ContentEncoder[Json] = new ContentEncoder[Json] {
-    def apply(data: Json) = ContentEncoder.text()(data.toString).addHeaders(
+    def apply(data: Json) = ContentEncoder.text()(data.noSpaces).addHeaders(
       Headers.ContentType -> h"application/json; charset=$codec"
     )
   }

--- a/json/src/test/scala/JsonTests.scala
+++ b/json/src/test/scala/JsonTests.scala
@@ -27,11 +27,11 @@ class JsonTests extends Tests {
   test("JSON encoding") {
     val jsonContent = Content.of(someJson)
     jsonContent.headers.get(Headers.ContentType) should be (Some(h"application/json; charset=UTF-8"))
-    jsonContent.headers.get(Headers.ContentLength) should be (Some(HttpString(someJson.toString.size)))
+    jsonContent.headers.get(Headers.ContentLength) should be (Some(HttpString(someJson.noSpaces.size)))
 
     val caseClassContent = Content.of(Blah("bar", 123, Seq(4, 5, 6)).asJson)
     caseClassContent.headers.get(Headers.ContentType) should be (Some(h"application/json; charset=UTF-8"))
-    caseClassContent.headers.get(Headers.ContentLength) should be (Some(HttpString(someJson.toString.size)))
+    caseClassContent.headers.get(Headers.ContentLength) should be (Some(HttpString(someJson.noSpaces.size)))
   }
 
   test("JSON decoding") {


### PR DESCRIPTION
Circe's Json.toString method prints JSON values with two spaces, which does no good but increases the content size to transmit.