### PR TITLE
Add Json examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,8 @@ lazy val loljson =
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core",
       "io.circe" %% "circe-generic",
-      "io.circe" %% "circe-parser"
+      "io.circe" %% "circe-parser",
+      "io.circe" %% "circe-optics"
     ).map(_ % "0.7.1") ++ Seq(
       "org.scalatest" %% "scalatest" % "3.0.3" % "test"
     ),
@@ -177,13 +178,14 @@ lazy val examples: Project =
   settings(
     Option(System.getProperty("generateExamples")).map(_ => Seq(
       autoCompilerPlugins := true,
-      addCompilerPlugin("com.criteo.socco" %% "socco-plugin" % "0.1.1"),
+      addCompilerPlugin("com.criteo.socco" %% "socco-plugin" % "0.1.5"),
       scalacOptions := Seq(
         "-P:socco:out:examples/target/html",
         "-P:socco:package_lol.html:https://criteo.github.io/lolhttp/api/",
         "-P:socco:package_lol.json:https://criteo.github.io/lolhttp/api/",
         "-P:socco:package_lol.http:https://criteo.github.io/lolhttp/api/",
         "-P:socco:package_scala.concurrent:http://www.scala-lang.org/api/current/",
+        "-P:socco:package_io.circe:http://circe.github.io/circe/api/",
         "-P:socco:package_fs2:https://oss.sonatype.org/service/local/repositories/releases/archive/co/fs2/fs2-core_2.12/0.9.4/fs2-core_2.12-0.9.4-javadoc.jar/!/"
       )
     )).getOrElse(Nil): _*

--- a/core/src/main/scala/Errors.scala
+++ b/core/src/main/scala/Errors.scala
@@ -50,4 +50,7 @@ object Error {
 
   /** The url matcher pattern is invalid. */
   def InvalidUrlMatcher(msg: String) = Error(9, s"Invalid url matcher pattern: $msg")
+
+  /** The status code was unexpected. */
+  def UnexpectedStatus(msg: String) = Error(10, msg)
 }

--- a/core/src/main/scala/internal/internal.scala
+++ b/core/src/main/scala/internal/internal.scala
@@ -2,6 +2,11 @@ package lol.http
 
 package object internal {
 
+  // Sometimes we don't want to pollute the API by asking an executionContext, so
+  // we will use this one internally. It will be only used for internal non-blocking operations when
+  // no user code is involved.
+  val nonBlockingInternalExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
   def extract(url: String): (String, String, Int, String, Option[String]) = {
     val url0 = new java.net.URL(url)
     val path = if(url0.getPath.isEmpty) "/" else url0.getPath

--- a/core/src/test/scala/ServerTests.scala
+++ b/core/src/test/scala/ServerTests.scala
@@ -96,16 +96,16 @@ class ServerTests extends Tests {
     }) { server =>
       val url = s"http://localhost:${server.port}"
 
-      status(Get(s"$url/")) should be (307)
-      status(Get(s"$url/old")) should be (308)
-      status(Get(s"$url/lol")) should be (200)
-      status(Get(s"$url/wat")) should be (404)
+      status(Get(s"$url/"), followRedirects = false) should be (307)
+      status(Get(s"$url/old"), followRedirects = false) should be (308)
+      status(Get(s"$url/lol"), followRedirects = false) should be (200)
+      status(Get(s"$url/wat"), followRedirects = false) should be (404)
 
-      contentString(Get(s"$url/")) should be ("")
-      contentString(Get(s"$url/lol")) should be ("lol")
+      contentString(Get(s"$url/"), followRedirects = false) should be ("")
+      contentString(Get(s"$url/lol"), followRedirects = false) should be ("lol")
 
-      await() { Client.run(Get(s"$url/"), followRedirects = true)(_.readAs[String]) } should be ("lol")
-      await() { Client.run(Get(s"$url/old"), followRedirects = true)(_.readAs[String]) } should be ("lol")
+      contentString(Get(s"$url/"), followRedirects = true) should be ("lol")
+      contentString(Get(s"$url/lol"), followRedirects = true) should be ("lol")
     }
   }
 
@@ -120,7 +120,6 @@ class ServerTests extends Tests {
           Ok(s"Took $contentSize bytes")
         }
     }) { server =>
-      val url = s"http://localhost:${server.port}"
       def oneMeg = Content(
         Stream.eval(Task.delay(Chunk.bytes(("A" * 1024).getBytes("us-ascii")))).
           repeat.

--- a/core/src/test/scala/Tests.scala
+++ b/core/src/test/scala/Tests.scala
@@ -16,11 +16,11 @@ abstract class Tests extends FunSuite with Matchers with OptionValues with Insid
   def await[A](atMost: Duration = 30 seconds)(a: Future[A]): A = Await.result(a, atMost)
   def withServer(server: Server)(test: Server => Unit) = try { test(server) } finally { server.stop() }
   def success[A](a: A) = Future.successful(a)
-  def status(req: Request, atMost: Duration = 5 seconds)(implicit e: ExecutionContext, ssl: SSL.Configuration): Int = {
-    await(atMost) { Client.run(req)(res => success(res.status)) }
+  def status(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.Configuration): Int = {
+    await(atMost) { Client.run(req, followRedirects = followRedirects)(res => success(res.status)) }
   }
-  def contentString(req: Request, atMost: Duration = 5 seconds)(implicit e: ExecutionContext, ssl: SSL.Configuration): String = {
-    await(atMost) { Client.run(req)(_.readAs[String]) }
+  def contentString(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.Configuration): String = {
+    await(atMost) { Client.run(req, followRedirects = followRedirects)(_.readAs[String]) }
   }
   def headers(req: Request, atMost: Duration = 5 seconds)(implicit e: ExecutionContext, ssl: SSL.Configuration): Map[HttpString,HttpString] = {
     await(atMost) { Client.run(req)(res => Future.successful(res.headers)) }

--- a/examples/src/main/scala/GithubClient.scala
+++ b/examples/src/main/scala/GithubClient.scala
@@ -1,0 +1,78 @@
+// Example: A Github API client
+
+// In this example we want to use the Github Json API, to retrieve
+// and list all the repositories under the __criteo__ account.
+import lol.http._
+import lol.json._
+
+// We will use [circe](https://circe.github.io/circe/) to handle
+// the Json Http requests and responses.
+import io.circe._
+import io.circe.optics.JsonPath._
+
+import scala.util._
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+
+// - - -
+
+object GithubClient {
+  def main(args: Array[String]): Unit = {
+
+    // Let's start by creating an Http client connected to Github.
+    // Because we have several requests to send to the API, it is more
+    // efficient to keep a client connected for the duration of the program.
+    // It will open and maintain a number of HTTP connections that will be reused
+    // accross requests.
+    val githubClient = Client("api.github.com", 443, "https")
+
+    // Github requires that we have a User-Agent for our requests.
+    val userAgent = (h"User-Agent" -> h"lolhttp")
+
+    val criteoRepositories = for {
+
+      // First thing, we retrieve all the repositories for the criteo
+      // organization.
+      //
+      // We use the `run` operation here: it takes the HTTP
+      // request to process and a block that will transform the HTTP response
+      // into a value of your choice. After the future completion, it will
+      // automatically drain the unread content if needed so the connection
+      // is ready for the next request.
+      repositories <- githubClient.run(Get("/users/criteo/repos").addHeaders(userAgent)) {
+        _.readSuccessAs[Json].map(root.each.full_name.string.getAll)
+      }
+
+      // Next, for each repository we make an additional HTTP request to
+      // retrieve the repository description (It is useless since the
+      // description was already available in the first request, but it
+      // is just for the sake of the example 😊).
+      descriptions <- Future.sequence(repositories.map { repository =>
+        githubClient.run(Get(url"/repos/$repository").addHeaders(userAgent)) {
+          _.readSuccessAs[Json].map(root.description.string.getOption)
+        }
+      })
+    } yield repositories.zip(descriptions)
+
+    // - - -
+
+    // Eventually, we can just display the result...
+    criteoRepositories.
+      andThen {
+        case Success(result) =>
+          result.foreach { case (repository, description) =>
+            println(s"""- $repository:""")
+            println(s"""  ${description.getOrElse("No description")}""")
+          }
+        case Failure(error) =>
+          println(s"Could not fetch criteo github repositories")
+          error.printStackTrace()
+          System.exit(-1)
+      }.
+      andThen { case _ =>
+
+        // and then, we shutdown the HTTP client.
+        githubClient.stop()
+      }
+  }
+}

--- a/examples/src/main/scala/JsonWebService.scala
+++ b/examples/src/main/scala/JsonWebService.scala
@@ -1,0 +1,137 @@
+// Example: A Json web service
+
+// Let's write a very minimal TODO application providing a Json web API.
+import lol.http._
+import lol.json._
+import lol.html._
+
+// We will use [circe](https://circe.github.io/circe/) as Json library
+// for this example. You should first have a look a the circe documentation
+// to understand the basics.
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.auto._
+import io.circe.optics.JsonPath._
+
+import scala.util._
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+
+// - - -
+object JsonWebService {
+
+  // First, let's define a Todo case class. We let the circe macro automatically
+  // generate the corresponding Json encoder/decoder for this type.
+  case class Todo(id: Int, text: String, done: Boolean)
+
+  // Also, we define an ordering for our todo values so we always list them is the right order.
+  implicit val mostRecentTodoFirst: Ordering[Todo] = Ordering.by(todo => -todo.id)
+
+  // And here is a simple helper that will be used to generate _Error_ Json values.
+  def Error(msg: String): Json = Json.obj("error" -> Json.fromString(msg))
+
+  // - - -
+
+  // This is our state. We use a concurrent Map for storing the
+  // data, and an atomic counter to generate the identifiers sequence.
+  val todos = collection.concurrent.TrieMap.empty[Int,Todo]
+  val idCounter = new java.util.concurrent.atomic.AtomicInteger(0)
+
+  // - - -
+
+  // Let's start by defining the Html part of our app. It is a `PartialService`
+  // because it does not respond to all the incoming requests.
+  lazy val App: PartialService = {
+    case GET at url"/" =>
+      // By using the `html` interpolation, we generate a very minimal UI 🎷.
+      Ok(html"""
+        <h1>${if(todos.isEmpty) "Nothing" else "A ton of things"} to do.</h1>
+        <ol>
+          ${todos.values.toSeq.sorted.map { case Todo(_, text, done) =>
+            html"""<li style="text-decoration: ${if(done) "line-through" else "none"}">$text</li>"""
+          }}
+        <ol>
+      """)
+    }
+
+  // - - -
+
+  // Then we define the Json API part. It contains all the endpoint needed
+  // to create, list, update and delete todos.
+  lazy val Api: PartialService = {
+
+    // This matcher will only match GET Http requests specifying the done parameter
+    // in their query string.
+    case GET at url"/api/todos?done=$doneFilter" =>
+      Try(doneFilter.toBoolean) match {
+        // If the done parameter value was not a boolean value, we fail with a `BadRequest`
+        // response.
+        case Failure(_) =>
+          BadRequest(Error(s"Invalid value for the done parameter: `$doneFilter'"))
+        // Otherwise we extract the actual list of todos and we transform it into a Json array.
+        case Success(isDone) =>
+          Ok(todos.values.toSeq.filter(_.done == isDone).sorted.asJson)
+      }
+
+    // Same as before, but here we match requests without the done parameter in the query string.
+    case GET at url"/api/todos" =>
+      Ok(todos.values.toSeq.sortBy(_.id).asJson)
+
+    // For this one, we actually need to get a reference of the request value, because we want
+    // to consume it's json content.
+    case request @ POST at url"/api/todos" =>
+      // We first try to read to content into a Json value (this is an asynchronous operation and the
+      // Future will fail if the Json can't be parsed).
+      //
+      // Then we use Circe optics to extract the `text` field from the incoming Json.
+      request.readAs[Json].map(root.text.string.getOption).map(_.get).map { text =>
+        val nextId = idCounter.incrementAndGet
+        val newTodo = Todo(nextId, text, false)
+        todos += (nextId -> newTodo)
+        Created(newTodo.asJson)
+      }.recover { case _ =>
+        BadRequest(Error("Please specify the `text' field for this item."))
+      }
+
+    // Nothing special here, but look how we handle the 404 case.
+    case GET at url"/api/todos/$id" =>
+      Try(id.toInt).toOption.flatMap(todos.get).map { todo =>
+        Ok(todo.asJson)
+      }.getOrElse {
+        NotFound(Error(s"No todo found for id: `$id'"))
+      }
+
+    // Again we need to keep a reference on the request in order to read the
+    // json body.
+    case request @ POST at url"/api/todos/$id" =>
+      Try(id.toInt).toOption.flatMap(todos.get).map { todo =>
+        request.readAs[Json].map { jsonBody =>
+          val updatedTodo = todo.copy(
+            text = root.text.string.getOption(jsonBody).getOrElse(todo.text),
+            done = root.done.boolean.getOption(jsonBody).getOrElse(todo.done)
+          )
+          todos += (todo.id -> updatedTodo)
+          Ok(updatedTodo.asJson)
+        }
+      }.getOrElse {
+        NotFound(Error(s"No todo found for id: `$id'"))
+      }
+
+    // Our last route handle deletion of the todos. Because deletion is idempotent
+    // we succeed even if the id was not found.
+    case DELETE at url"/api/todos/$id" =>
+      todos -= Try(id.toInt).toOption.getOrElse(-1)
+      Ok
+  }
+
+  // - - -
+
+  def main(args: Array[String]): Unit = {
+    // It is now time to actually bootstrap the application. We start an HTTP server, and we
+    // compose the App and Api functions we just defined.
+    Server.listen(8888)(App.orElse(Api).orElse { case _ => NotFound })
+
+    // Done! We can use a Json client to interact with the app.
+    println("Listening on http://localhost:8888...")
+  }
+}

--- a/examples/src/main/scala/LargeFileUpload.scala
+++ b/examples/src/main/scala/LargeFileUpload.scala
@@ -13,6 +13,7 @@ import lol.html._
 import scala.concurrent._
 import ExecutionContext.Implicits.global
 
+// - - -
 object LargeFileUpload {
   def main(args: Array[String]): Unit = {
 

--- a/examples/src/test/scala/StressTests.scala
+++ b/examples/src/test/scala/StressTests.scala
@@ -3,8 +3,6 @@ package lol.http.examples
 import lol.http._
 import lol.json._
 
-import io.circe._
-import io.circe.syntax._
 import io.circe.parser._
 
 import scala.concurrent._


### PR DESCRIPTION
- Add Json examples.
- followRedirects is now the default for Client.run operations.
- Add new helpers on Response to consume the content only for 2xx statuses.