### PR TITLE
Remove Client.maxWaiters

### DIFF
--- a/core/src/main/scala/Errors.scala
+++ b/core/src/main/scala/Errors.scala
@@ -38,9 +38,6 @@ object Error {
   /** It is not possible to upgrade the connection because the server did not allow it. */
   val UpgradeRefused = Error(4, "Connection upgrade was denied by the server")
 
-  /** An HTTP client cannot handle new request because there are already too many waiters. */
-  val TooManyWaiters = Error(5, "Client has already too many waiting requests")
-
   /** Auto-redirect is only supported for GET requests. */
   val AutoRedirectNotSupported = Error(6, "Automatic redirects is only allowed for GET requests")
 


### PR DESCRIPTION
Because we have a connection timeout, we can use an unbounded queue for
waiting requests.