### PR TITLE
Fix URL pattern matching.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val VERSION = "0.4.0"
+val VERSION = "0.4.1"
 
 lazy val commonSettings = Seq(
   organization := "com.criteo.lolhttp",

--- a/core/src/test/scala/UrlTests.scala
+++ b/core/src/test/scala/UrlTests.scala
@@ -31,7 +31,9 @@ class UrlsTests extends Tests {
     "/?sort=asc&page=2" match { case url"/?page=$page&sort=desc" => fail(); case _ => succeed }
     "/?sort=asc&page=2" match { case url"/?sort=asc" => succeed }
     "/?sort=asc&page=2" match { case url"/?sort=desc" => fail(); case _ => succeed }
-    "/" match { case url"/?page=$page" => fail(); case _ => succeed }
+    "/?sort=asc" match { case url"/?page=$page" => page should be ("") }
+    "/" match { case url"/?page=$page" => page should be ("") }
+    "/" match { case url"/?page=$page&sort=asc" => fail(); case _ => succeed }
     "/?page=2&page=4" match { case url"/?page=$page" => fail(); case _ => succeed }
     "/?sort=sort-asc&page=2" match { case url"/?sort=sort-$sort" => sort should be ("asc") }
     "/?name=jean-claude" match { case url"/?name=$first-$last" => (first,last) should be ("jean" -> "claude") }


### PR DESCRIPTION
Missing queryString parameters should just match as "" (empty string)
instead of making the matching fail.