### PR TITLE
Fix binary interface problem for scala 2.11 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Servers and clients are service functions. A service takes an HTTP request and e
 
 The library is cross-built for __Scala 2.11__ and __Scala 2.12__.
 
-The core module to use is `"com.criteo.lolhttp" %% "lolhttp" % "0.4.2"`.
+The core module to use is `"com.criteo.lolhttp" %% "lolhttp" % "0.4.3"`.
 
 There are also 2 optional companion libraries:
 
-- `"com.criteo.lolhttp" %% "loljson" % "0.4.2"`, provides integration with the [circe](https://circe.github.io/circe/) JSON library.
-- `"com.criteo.lolhttp" %% "lolhtml" % "0.4.2"`, provides minimal HTML templating.
+- `"com.criteo.lolhttp" %% "loljson" % "0.4.3"`, provides integration with the [circe](https://circe.github.io/circe/) JSON library.
+- `"com.criteo.lolhttp" %% "lolhtml" % "0.4.3"`, provides minimal HTML templating.
 
 ## Documentation
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
-val VERSION = "0.4.2"
+val VERSION = "0.4.3"
 
 lazy val commonSettings = Seq(
   organization := "com.criteo.lolhttp",
   version := VERSION,
   scalaVersion := "2.12.2",
-  crossScalaVersions := Seq("2.11.8", "2.12.2"),
+  crossScalaVersions := Seq("2.11.11", "2.12.2"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
A io.netty symbol was exposed in the Client trait and for some reasons
not properly rewritten by sbt assembly shade when compiling in scala 2.11.
The generated package was unusable for a scala 2.11 project using the
Client type.