### PR TITLE
Refactor SSL API & impl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val VERSION = "0.4.3"
+val VERSION = "0.5.0"
 
 lazy val commonSettings = Seq(
   organization := "com.criteo.lolhttp",
@@ -108,8 +108,6 @@ lazy val lolhttp =
     libraryDependencies ++= Seq(
       "co.fs2" %% "fs2-core" % "0.9.5",
       "io.netty" % "netty-codec-http2" % "4.1.11.Final",
-      "org.bouncycastle" % "bcpkix-jdk15on" % "1.56",
-      "org.bouncycastle" % "bcprov-jdk15on" % "1.56",
       "org.scalatest" %% "scalatest" % "3.0.1" % "test"
     ),
 

--- a/core/src/test/scala/SSLTests.scala
+++ b/core/src/test/scala/SSLTests.scala
@@ -8,16 +8,7 @@ class SSLTests extends Tests {
   val App: Service = { request => Ok("Well done") }
 
   test("SSL over self signed certificate") {
-    implicit val selfSignedSSL = SSL.selfSigned()
-
-    withServer(Server.listen(ssl = Some(selfSignedSSL))(App)) { server =>
-      contentString(Get(s"https://localhost:${server.port}/")) should be ("Well done")
-    }
-  }
-
-  test("allow insecure connection") {
     implicit val trustAll = SSL.trustAll
-
     withServer(Server.listen(ssl = Some(SSL.selfSigned()))(App)) { server =>
       contentString(Get(s"https://localhost:${server.port}/")) should be ("Well done")
     }

--- a/core/src/test/scala/Tests.scala
+++ b/core/src/test/scala/Tests.scala
@@ -16,13 +16,13 @@ abstract class Tests extends FunSuite with Matchers with OptionValues with Insid
   def await[A](atMost: Duration = 30 seconds)(a: Future[A]): A = Await.result(a, atMost)
   def withServer(server: Server)(test: Server => Unit) = try { test(server) } finally { server.stop() }
   def success[A](a: A) = Future.successful(a)
-  def status(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.Configuration): Int = {
+  def status(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): Int = {
     await(atMost) { Client.run(req, followRedirects = followRedirects)(res => success(res.status)) }
   }
-  def contentString(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.Configuration): String = {
+  def contentString(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): String = {
     await(atMost) { Client.run(req, followRedirects = followRedirects)(_.readAs[String]) }
   }
-  def headers(req: Request, atMost: Duration = 5 seconds)(implicit e: ExecutionContext, ssl: SSL.Configuration): Map[HttpString,HttpString] = {
+  def headers(req: Request, atMost: Duration = 5 seconds)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): Map[HttpString,HttpString] = {
     await(atMost) { Client.run(req)(res => Future.successful(res.headers)) }
   }
   def getString(content: Content, codec: String = "utf-8") = new String(getBytes(content).toArray, codec)


### PR DESCRIPTION
- Split configuration in both Client & Server configurations.
- Use internal Netty SSL utils and drop BouncyCastle.