### PR TITLE
lol.http.internal.timer was preventing JVM to exit

### DIFF
--- a/core/src/main/scala/internal/internal.scala
+++ b/core/src/main/scala/internal/internal.scala
@@ -34,7 +34,7 @@ package object internal {
     }.getOrElse("application/octet-stream")
   }
 
-  val timer = new Timer("lol.http.internal.timer")
+  val timer = new Timer("lol.http.internal.timer", true)
   def timeout[A](a: => A, duration: FiniteDuration): Future[A] = {
     val e = Promise[A]
     timer.schedule(new TimerTask { def run(): Unit = e.success(a) }, duration.toMillis)


### PR DESCRIPTION
Making the associated thread a daemon solves the problem.