### PR TITLE
Kill connection timeout.

### DIFF
--- a/core/src/main/scala-2.11/internal/KillableFuture.scala
+++ b/core/src/main/scala-2.11/internal/KillableFuture.scala
@@ -4,7 +4,7 @@ import scala.util._
 import scala.concurrent._
 import scala.concurrent.duration._
 
-private[http] case class KillableFuture[+A](wrapped: Future[A], cancel: () => Unit) extends Future[A] {
+private[http] case class KillableFuture[+A](wrapped: Future[A], cancel: () => Unit = () => ()) extends Future[A] {
   def ready(atMost: Duration)(implicit permit: CanAwait) = { wrapped.ready(atMost); this }
   def result(atMost: Duration)(implicit permit: CanAwait): A = wrapped.result(atMost)
   def isCompleted = wrapped.isCompleted

--- a/core/src/main/scala-2.12/internal/KillableFuture.scala
+++ b/core/src/main/scala-2.12/internal/KillableFuture.scala
@@ -4,7 +4,7 @@ import scala.util._
 import scala.concurrent._
 import scala.concurrent.duration._
 
-private[http] case class KillableFuture[+A](wrapped: Future[A], cancel: () => Unit) extends Future[A] {
+private[http] case class KillableFuture[+A](wrapped: Future[A], cancel: () => Unit = () => ()) extends Future[A] {
   def ready(atMost: Duration)(implicit permit: CanAwait) = { wrapped.ready(atMost); this }
   def result(atMost: Duration)(implicit permit: CanAwait): A = wrapped.result(atMost)
   def isCompleted: Boolean = wrapped.isCompleted


### PR DESCRIPTION
Instead we manage a single global timeout for the whole request execution.
Also fail fast connection waiters when we fail obtaining a new connection.