### PR TITLE
Close ServerChannelGroup when stopping the server

### DIFF
--- a/core/src/main/scala/Server.scala
+++ b/core/src/main/scala/Server.scala
@@ -245,11 +245,16 @@ object Server {
             }
           }
         }
+      private val group: ServerChannelGroup = NIO1SocketServerGroup.fixedGroup(workerThreads = 4)
       val ch =
-        NIO1SocketServerGroup.fixedGroup(workerThreads = 4).bind(new InetSocketAddress(address, port0), f)
+        group.bind(new InetSocketAddress(address, port0), f)
           .getOrElse(sys.error(s"Failed to start server on port $port0"))
       val socketAddress = ch.socketAddress
-      def stop() = ch.close()
+      def stop() = {
+        ch.close()
+        ch.join()
+        group.closeGroup
+      }
       def apply(req: Request) = serveRequest(req)
 
       // Keep the server alive until `stop()` is called.


### PR DESCRIPTION
Closing the channel is not enough. The underlying thread pool is still alive after stopping the server.
During server.stop(), it should close the channel, wait for the close and then close the ChannelGroup. It will take care of shutting down the thread pool.