### PR TITLE
Add explicit dependency on scala-reflect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,8 @@ lazy val lolhtml =
     commonSettings,
 
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "fastparse" % "1.0.0"
+      "com.lihaoyi" %% "fastparse" % "1.0.0",
+      scalaOrganization.value % "scala-reflect" % scalaVersion.value
     ),
     pomPostProcess := removeDependencies("org.scalatest")
   ).


### PR DESCRIPTION
- lolhtml explicitly uses scala-reflect, but only depended on it
transitively through cats
- Bumping cats would remove this transitive dependency, so we should add
it explicitly