### PR TITLE
Shift to user provided context shift

### DIFF
--- a/core/src/main/scala/Server.scala
+++ b/core/src/main/scala/Server.scala
@@ -108,7 +108,7 @@ object Server {
     val emptyBuffer = ByteBuffer.allocate(0)
 
     def serveRequest(request: Request): IO[Response] =
-      IO.suspend(service(request)).attempt.map {
+      cs.shift >> IO.suspend(service(request)).attempt.map {
         case Left(e) => Try(onError(e)).toOption.getOrElse(defaultErrorResponse)
         case Right(x) => x
       }


### PR DESCRIPTION
user provided `ContextShift` is not used. Blaze selector is
executing user-level code. Added `contextShift.shift` to fix