### PR TITLE
Bump version to 0,13,2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val VERSION = "0.13.1"
+val VERSION = "0.13.2"
 
 lazy val commonSettings = Seq(
   organization := "com.criteo.lolhttp",


### PR DESCRIPTION
No change since last version in the library.
We only migrated from travis to github actions for the CI/CD